### PR TITLE
fix: set private to false

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,7 +3,7 @@ nmHoistingLimits: workspaces
 
 npmScopes:
   liatrio:
-    npmAlwaysAuth: true
     npmRegistryServer: "https://npm.pkg.github.com"
+    npmAlwaysAuth: false
 
 yarnPath: .yarn/releases/yarn-4.4.1.cjs

--- a/backstage-plugin-autogov-common/package.json
+++ b/backstage-plugin-autogov-common/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
+  "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/liatrio/backstage-github-autogov-plugin.git",

--- a/backstage-plugin-github-releases-assets-backend/package.json
+++ b/backstage-plugin-github-releases-assets-backend/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
+  "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/liatrio/backstage-github-autogov-plugin.git",

--- a/backstage-plugin-github-releases-autogov/package.json
+++ b/backstage-plugin-github-releases-autogov/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
+  "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/liatrio/backstage-github-autogov-plugin.git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@liatrio/backstage-github-autogov-plugin",
-  "version": "1.2.1",
-  "private": true,
+  "version": "1.2.5",
+  "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/liatrio/backstage-github-autogov-plugin.git"


### PR DESCRIPTION
private: false is needed to pull packages from GitHub npm registry without authorization 